### PR TITLE
export a default ollama client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,3 +150,5 @@ export class Ollama {
 		return json.embedding;
 	}
 }
+
+export default new Ollama();


### PR DESCRIPTION
Allow ollama to be used without instantiating a client, this matches the Python SDK's default client.

```
import ollama from 'ollama';

for await (const generateResult of ollama.generate("llama2", "Say 'Hello, World!'")) {
    process.stdout.write(generateResult.response);
}
```