### PR TITLE
use whatwg-fetch to allow default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@swc/core": "^1.3.14",
     "@types/jest": "^29.2.2",
+    "@types/whatwg-fetch": "^0.0.33",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "eslint": "^8.29.0",
@@ -28,5 +29,8 @@
     "jest": "^29.3.0",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as utils from "./utils.js";
+import 'whatwg-fetch';
 import { promises, createReadStream } from 'fs';
 import { join, resolve, dirname } from 'path';
 import { createHash } from 'crypto';
@@ -31,27 +32,16 @@ export class Ollama {
 	private readonly config: Config;
 	private readonly fetch: Fetch;
 
-	constructor (config?: Partial<Config>) {
-		this.config = {
-			address: config?.address ?? "http://127.0.0.1:11434"
-		};
-
-		let f: Fetch | null = null;
-
-		if (config?.fetch != null) {
-			f = config.fetch;
-		} else if (typeof fetch !== "undefined") {
-			f = fetch;
-		} else if (typeof window !== "undefined") {
-			f = window.fetch;
-		}
-
-		if (f == null) {
-			throw new Error("unable to find fetch - please define it via 'config.fetch'");
-		}
-
-		this.fetch = f;
-	}
+    constructor (config?: Partial<Config>) {
+        this.config = {
+            address: config?.address ?? "http://127.0.0.1:11434"
+        };
+    
+        this.fetch = fetch;
+        if (config?.fetch != null) {
+            this.fetch = config.fetch;
+        }
+    }
 
     private async processStreamableRequest<T extends object>(endpoint: string, request: { stream?: boolean } & Record<string, any>): Promise<T | AsyncGenerator<T>> {
         request.stream = request.stream ?? false;
@@ -287,3 +277,5 @@ export class Ollama {
 		return embeddingsResponse;
 	}
 }
+
+export default new Ollama();


### PR DESCRIPTION
As mentioned in #6, exporting a default ollama client was not possible as we rely on `window.fetch` and if it's not available an error is thrown.

This PR:
- Adds `whatwg-fetch` as a default fetch library so that there is always a fetch library available.
- Exports a default ollama client so that ollama can be used like this:
```
import ollama from 'ollama';

for await (const generateResult of ollama.generate("llama2", "Say 'Hello, World!'")) {
    process.stdout.write(generateResult.response);
}
```

The other option is to lazy-load the `fetch` library, and fail when it is used, but I thought it could be better to be more consistent instead.