### PR TITLE
docs(readme): add Cloud Models JS usage and Cloud API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,7 @@ Access cloud models directly by pointing the client at `https://ollama.com`.
 export OLLAMA_API_KEY=your_api_key
 ```
 
-2) (Optional) List models available via the API:
-
-```
-curl https://ollama.com/api/tags
-```
-
-3) Generate a response via the cloud API:
+2) Generate a response via the cloud API:
 
 ```javascript
 import { Ollama } from 'ollama'


### PR DESCRIPTION
Introduce a minimal, focused Cloud Models section for JavaScript users.

Why
- Clarify how to run larger models via cloud offload while keeping local tooling.
- Document direct access to ollama.com’s API with a JS example.

What
- Add sign-in/pull/run flow for cloud models via local Ollama (automatic offload).
- Add example for direct cloud API with host="https://ollama.com" and OLLAMA_API_KEY header.
- List currently supported cloud model IDs.
- Keep examples concise; align with existing code style and streaming pattern.

Scope
- JS-only; no Python/cURL to avoid duplication.
- Docs-only change; no runtime or API modifications.

Validation
- Verified examples locally (streaming + basic chat).
- Ensured README anchors and ordering remain consistent.
