### PR TITLE
Remove a duplicate line in the .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@ node_modules
 build
 .docs
 .coverage
-node_modules
 package-lock.json
 yarn.lock
 .vscode


### PR DESCRIPTION
Hello,

I was reviewing the codebase and found a duplicate `node_modules` line in the `.npmignore`.  I believe this is not needed and made this PR to remove it. If there are any other steps required, please let me know.

Thanks