### PR TITLE
browser: add method to retrieve server version

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -328,6 +328,17 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
   }
 
   /**
+   * Returns the Ollama server version.
+   * @returns {Promise<{version: string}>} - The server version object.
+   */
+  async version(): Promise<{ version: string }> {
+    const response = await utils.get(this.fetch, `${this.config.host}/api/version`, {
+      headers: this.config.headers,
+    })
+    return (await response.json()) as { version: string }
+  }
+
+  /**
    * Performs web search using the Ollama web search API
    * @param request {WebSearchRequest} - The search request containing query and options
    * @returns {Promise<WebSearchResponse>} - The search results


### PR DESCRIPTION
Added a ```version``` method to retrieve Ollama server version. It fetches it from ```/api/version```

Usage:
```javascript
import { Ollama } from 'ollama'

const ollama = new Ollama({ host: 'http://127.0.0.1:11434' })
const res = await ollama.version()
```

Addresses #258
