### PR TITLE
browser/interfaces: add VersionResponse type and add ollama.version()…

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ ollama.ps()
 
 - Returns: `<ListResponse>`
 
+### version
+
+```javascript
+ollama.version()
+```
+
+- Returns: `<VersionResponse>`
+
 ### abort
 
 ```javascript

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -28,6 +28,7 @@ import type {
   WebSearchResponse,
   WebFetchRequest,
   WebFetchResponse,
+  VersionResponse,
 } from './interfaces.js'
 import { defaultHost } from './constant.js'
 
@@ -329,13 +330,13 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
 
   /**
    * Returns the Ollama server version.
-   * @returns {Promise<{version: string}>} - The server version object.
+   * @returns {Promise<VersionResponse>} - The server version object.
    */
-  async version(): Promise<{ version: string }> {
+  async version(): Promise<VersionResponse> {
     const response = await utils.get(this.fetch, `${this.config.host}/api/version`, {
       headers: this.config.headers,
     })
-    return (await response.json()) as { version: string }
+    return (await response.json()) as VersionResponse
   }
 
   /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -272,6 +272,10 @@ export interface ShowResponse {
   projector_info?: Map<string, any>
 }
 
+export interface VersionResponse {
+  version: string
+}
+
 export interface ListResponse {
   models: ModelResponse[]
 }


### PR DESCRIPTION
Added a `<VersionResponse>` to interfaces.ts in order for `version()` to be consistent with the rest of the code. Also added `version()` method to README