### PR TITLE
interfaces: mark optional response fields

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -193,15 +193,17 @@ export interface GenerateResponse {
   response: string
   thinking?: string
   done: boolean
-  done_reason: string
-  context: number[]
-  total_duration: number
-  load_duration: number
-  prompt_eval_count: number
-  prompt_eval_duration: number
-  eval_count: number
-  eval_duration: number
+  done_reason?: string
+  context?: number[]
+  total_duration?: number
+  load_duration?: number
+  prompt_eval_count?: number
+  prompt_eval_duration?: number
+  eval_count?: number
+  eval_duration?: number
   logprobs?: Logprob[]
+  remote_model?: string
+  remote_host?: string
 }
 
 export interface ChatResponse {
@@ -209,14 +211,16 @@ export interface ChatResponse {
   created_at: Date
   message: Message
   done: boolean
-  done_reason: string
-  total_duration: number
-  load_duration: number
-  prompt_eval_count: number
-  prompt_eval_duration: number
-  eval_count: number
-  eval_duration: number
+  done_reason?: string
+  total_duration?: number
+  load_duration?: number
+  prompt_eval_count?: number
+  prompt_eval_duration?: number
+  eval_count?: number
+  eval_duration?: number
   logprobs?: Logprob[]
+  remote_model?: string
+  remote_host?: string
 }
 
 export interface EmbedResponse {


### PR DESCRIPTION
These fields will only be present on some responses, such as the final response in the stream or a remote model response.

resolves #262 