### PR TITLE
Add min_p parameter to Options interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,6 +30,7 @@ export interface Options {
   num_predict: number
   top_k: number
   top_p: number
+  min_p: number
   tfs_z: number
   typical_p: number
   repeat_last_n: number


### PR DESCRIPTION
Adds the `min_p` (minimum probability threshold) parameter to the Options interface. This parameter is supported by the Ollama API but was missing from the TypeScript definitions.

`min_p` works alongside `top_p` to control token selection during generation by setting a minimum probability threshold relative to the most likely token. Tokens with probabilities below this threshold are filtered out.

This addresses the missing parameter mentioned in issue #145.

**Changes:**
- Added `min_p: number` to the `Options` interface in `src/interfaces.ts`
- Positioned after `top_p` since they are related sampling parameters