### PR TITLE
browser: export AbortableAsyncIterator type

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -374,3 +374,5 @@ export default new Ollama()
 
 // export all types from the main entry point so that packages importing types dont need to specify paths
 export * from './interfaces.js'
+
+export type { AbortableAsyncIterator }

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import { Ollama } from '../src/browser'
 import type { ChatResponse, GenerateResponse } from '../src/interfaces'
+import type { AbortableAsyncIterator } from '../src/browser'
+
+describe('AbortableAsyncIterator type export', () => {
+  it('should be importable from browser module', () => {
+    const typeCheck = (_: AbortableAsyncIterator<ChatResponse> | null) => {}
+    typeCheck(null)
+    expect(true).toBe(true)
+  })
+})
 
 describe('Ollama logprob request fields', () => {
   it('forwards logprob settings in generate requests', async () => {


### PR DESCRIPTION
## Summary
- Export `AbortableAsyncIterator` type from the browser module
- Add test to verify type can be imported from `ollama/browser`

## Test plan
- [x] TypeScript compilation succeeds
- [x] Existing tests pass
- [x] New test verifies type export works

Fixes #135