### PR TITLE
fix: release ReadableStream reader after iteration completes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -308,6 +308,7 @@ export const parseJSON = async function* <T = unknown>(
     const { done, value: chunk } = await reader.read()
 
     if (done) {
+      reader.releaseLock()
       break
     }
 


### PR DESCRIPTION
The parseJSON function obtained a ReadableStreamDefaultReader but never called releaseLock() when iteration finished. This caused Deno's test runner to detect a memory leak with streaming responses.

resolves #241
