### PR TITLE
fix: make streaming response fields optional in ChatResponse and GenerateResponse

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -199,14 +199,14 @@ export interface GenerateResponse {
   response?: string
   thinking?: string
   done: boolean
-  done_reason: string
-  context: number[]
-  total_duration: number
-  load_duration: number
-  prompt_eval_count: number
-  prompt_eval_duration: number
-  eval_count: number
-  eval_duration: number
+  done_reason?: string
+  context?: number[]
+  total_duration?: number
+  load_duration?: number
+  prompt_eval_count?: number
+  prompt_eval_duration?: number
+  eval_count?: number
+  eval_duration?: number
   logprobs?: Logprob[]
 
   // Image generation response fields
@@ -220,13 +220,13 @@ export interface ChatResponse {
   created_at: Date
   message: Message
   done: boolean
-  done_reason: string
-  total_duration: number
-  load_duration: number
-  prompt_eval_count: number
-  prompt_eval_duration: number
-  eval_count: number
-  eval_duration: number
+  done_reason?: string
+  total_duration?: number
+  load_duration?: number
+  prompt_eval_count?: number
+  prompt_eval_duration?: number
+  eval_count?: number
+  eval_duration?: number
   logprobs?: Logprob[]
 }
 


### PR DESCRIPTION
## Summary
- Make fields that are only present in the final streaming response (when `done: true`) optional in the `ChatResponse` and `GenerateResponse` interfaces
- Fields affected: `done_reason`, `total_duration`, `load_duration`, `prompt_eval_count`, `prompt_eval_duration`, `eval_count`, `eval_duration`, and `context` (GenerateResponse only)
- These fields are not present in intermediate streaming chunks, so declaring them as required causes TypeScript type errors when iterating over streamed responses

Fixes #262

## Changes
- `src/interfaces.ts`: Add `?` optional modifier to completion-only fields in both `ChatResponse` and `GenerateResponse` interfaces

## Test plan
- [x] All existing tests pass (34/34)
- [x] Build succeeds with `unbuild`
- [x] Type declarations correctly reflect optional fields in generated `.d.ts` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)