### PR TITLE
fix(browser): transform maxResults to max_results for WebSearch API

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -349,7 +349,16 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
     if (!request.query || request.query.length === 0) {
       throw new Error('Query is required')
     }
-    const response = await utils.post(this.fetch, `https://ollama.com/api/web_search`, { ...request }, {
+
+    // Transform maxResults (camelCase) to max_results (snake_case) for API compatibility
+    const apiRequest: Record<string, unknown> = {
+      query: request.query,
+    }
+    if (request.maxResults !== undefined) {
+      apiRequest.max_results = request.maxResults
+    }
+
+    const response = await utils.post(this.fetch, `https://ollama.com/api/web_search`, apiRequest, {
       headers: this.config.headers
     })
     return (await response.json()) as WebSearchResponse


### PR DESCRIPTION
## Summary

The `WebSearchRequest` interface uses camelCase (`maxResults`), but the Ollama `/api/web_search` endpoint expects snake_case (`max_results`). The spread operator was passing the wrong parameter name.

## Problem

```ts
// Interface
export interface WebSearchRequest {
  query: string
  maxResults?: number  // camelCase
}

// API expects
POST /api/web_search { "query": "...", "max_results": 10 }  // snake_case
```

The previous code used `{ ...request }` which sent `maxResults` instead of `max_results`.

## Solution

Explicitly map the request parameters to the correct API parameter names:

```ts
const apiRequest: Record<string, unknown> = {
  query: request.query,
}
if (request.maxResults !== undefined) {
  apiRequest.max_results = request.maxResults
}
```

Fixes #283