### PR TITLE
feat: accept an external AbortSignal in chat() and generate()

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -66,6 +66,8 @@ export class Ollama {
    * object.
    * @param endpoint {string} - The endpoint to send the request to.
    * @param request {object} - The request object to send to the endpoint.
+   * @param signal {AbortSignal} - An optional external signal that aborts the request immediately,
+   * without waiting for the ongoing request cleanup that `this.abort()` goes through.
    * @protected {T | AbortableAsyncIterator<T>} - The response object or a AbortableAsyncIterator that yields
    * response messages.
    * @throws {Error} - If the response body is missing or if the response is an error.
@@ -74,11 +76,19 @@ export class Ollama {
   protected async processStreamableRequest<T extends object>(
     endpoint: string,
     request: { stream?: boolean } & Record<string, any>,
+    signal?: AbortSignal,
   ): Promise<T | AbortableAsyncIterator<T>> {
     request.stream = request.stream ?? false
     const host = `${this.config.host}/api/${endpoint}`
     if (request.stream) {
       const abortController = new AbortController()
+      if (signal) {
+        if (signal.aborted) {
+          abortController.abort()
+        } else {
+          signal.addEventListener('abort', () => abortController.abort(), { once: true })
+        }
+      }
       const response = await utils.post(this.fetch, host, request, {
         signal: abortController.signal,
         headers: this.config.headers
@@ -103,6 +113,7 @@ export class Ollama {
       return abortableAsyncIterator
     }
     const response = await utils.post(this.fetch, host, request, {
+      signal,
       headers: this.config.headers
     })
     return await response.json()
@@ -130,37 +141,53 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
 
   generate(
     request: GenerateRequest & { stream: true },
+    options?: { signal?: AbortSignal },
   ): Promise<AbortableAsyncIterator<GenerateResponse>>
-  generate(request: GenerateRequest & { stream?: false }): Promise<GenerateResponse>
+  generate(
+    request: GenerateRequest & { stream?: false },
+    options?: { signal?: AbortSignal },
+  ): Promise<GenerateResponse>
   /**
    * Generates a response from a text prompt.
    * @param request {GenerateRequest} - The request object.
+   * @param options {object} - Optional. An object with an `AbortSignal` that, when aborted, cancels
+   * this specific request immediately, independently of any other ongoing requests.
    * @returns {Promise<GenerateResponse | AbortableAsyncIterator<GenerateResponse>>} - The response object or
    * an AbortableAsyncIterator that yields response messages.
    */
   async generate(
     request: GenerateRequest,
+    options?: { signal?: AbortSignal },
   ): Promise<GenerateResponse | AbortableAsyncIterator<GenerateResponse>> {
     if (request.images) {
       request.images = await Promise.all(request.images.map(this.encodeImage.bind(this)))
     }
-    return this.processStreamableRequest<GenerateResponse>('generate', request)
+    return options?.signal
+      ? this.processStreamableRequest<GenerateResponse>('generate', request, options.signal)
+      : this.processStreamableRequest<GenerateResponse>('generate', request)
   }
 
   chat(
     request: ChatRequest & { stream: true },
+    options?: { signal?: AbortSignal },
   ): Promise<AbortableAsyncIterator<ChatResponse>>
-  chat(request: ChatRequest & { stream?: false }): Promise<ChatResponse>
+  chat(
+    request: ChatRequest & { stream?: false },
+    options?: { signal?: AbortSignal },
+  ): Promise<ChatResponse>
   /**
    * Chats with the model. The request object can contain messages with images that are either
    * Uint8Arrays or base64 encoded strings. The images will be base64 encoded before sending the
    * request.
    * @param request {ChatRequest} - The request object.
+   * @param options {object} - Optional. An object with an `AbortSignal` that, when aborted, cancels
+   * this specific request immediately, independently of any other ongoing requests.
    * @returns {Promise<ChatResponse | AbortableAsyncIterator<ChatResponse>>} - The response object or an
    * AbortableAsyncIterator that yields response messages.
    */
   async chat(
     request: ChatRequest,
+    options?: { signal?: AbortSignal },
   ): Promise<ChatResponse | AbortableAsyncIterator<ChatResponse>> {
     if (request.messages) {
       for (const message of request.messages) {
@@ -171,7 +198,9 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
         }
       }
     }
-    return this.processStreamableRequest<ChatResponse>('chat', request)
+    return options?.signal
+      ? this.processStreamableRequest<ChatResponse>('chat', request, options.signal)
+      : this.processStreamableRequest<ChatResponse>('chat', request)
   }
 
   create(

--- a/test/abort-signal.test.ts
+++ b/test/abort-signal.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Ollama } from '../src/browser'
+
+/**
+ * A fetch stand-in that behaves like the real thing with respect to
+ * AbortSignal: it never resolves on its own, and rejects with an
+ * AbortError as soon as the given signal fires.
+ */
+function createAbortAwareFetch() {
+  const fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (signal) {
+        if (signal.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'))
+          return
+        }
+        signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      }
+      // otherwise: never resolves, simulating a slow/hanging server
+    })
+  })
+  return fetch
+}
+
+describe('external AbortSignal for chat/generate (issue #274)', () => {
+  it('rejects immediately when an external signal aborts a non-streaming generate() call', async () => {
+    const fetch = createAbortAwareFetch()
+    const client = new Ollama({ fetch: fetch as any })
+    const controller = new AbortController()
+
+    const promise = client.generate(
+      { model: 'dummy', prompt: 'hello' },
+      { signal: controller.signal },
+    )
+
+    controller.abort()
+
+    await expect(promise).rejects.toThrow(/abort/i)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects immediately when an external signal aborts a streaming chat() call', async () => {
+    const fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        )
+      })
+    })
+    const client = new Ollama({ fetch: fetch as any })
+    const controller = new AbortController()
+
+    const promise = client.chat(
+      { model: 'dummy', messages: [{ role: 'user', content: 'hi' }], stream: true },
+      { signal: controller.signal },
+    )
+
+    controller.abort()
+
+    await expect(promise).rejects.toThrow(/abort/i)
+  })
+
+  it('rejects immediately if the external signal is already aborted before the call', async () => {
+    const fetch = createAbortAwareFetch()
+    const client = new Ollama({ fetch: fetch as any })
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      client.generate({ model: 'dummy', prompt: 'hello' }, { signal: controller.signal }),
+    ).rejects.toThrow(/abort/i)
+  })
+
+  it('still works with no signal passed at all (backward compatible)', async () => {
+    const client = new Ollama()
+    const spy = vi
+      .spyOn(client as any, 'processStreamableRequest')
+      .mockResolvedValue({ done: true })
+
+    await client.generate({ model: 'dummy', prompt: 'hello' })
+
+    expect(spy).toHaveBeenCalledWith('generate', expect.any(Object))
+  })
+
+  it('forwards options.signal through to processStreamableRequest', async () => {
+    const client = new Ollama()
+    const spy = vi
+      .spyOn(client as any, 'processStreamableRequest')
+      .mockResolvedValue({ done: true })
+    const controller = new AbortController()
+
+    await client.chat(
+      { model: 'dummy', messages: [{ role: 'user', content: 'hi' }] },
+      { signal: controller.signal },
+    )
+
+    expect(spy).toHaveBeenCalledWith('chat', expect.any(Object), controller.signal)
+  })
+})


### PR DESCRIPTION
Fixes #274.

`chat()` and `generate()` now take an optional second `{ signal }` argument, linked to the internal `AbortController` used for the request. Lets callers cancel a specific call immediately (e.g. tied to a component unmount) instead of only being able to abort *all* ongoing requests via `client.abort()`. Fully backward compatible - omitting it preserves the existing behavior and call shape exactly.

**Verification:** Added `test/abort-signal.test.ts` - a fetch stand-in that only resolves/rejects based on the AbortSignal it's given, so the tests exercise real cancellation, not just mocked call args. Confirmed these tests fail against the current code and pass with the fix. Full suite (39 tests) still passes, `tsc --noEmit` and `npm run lint` are clean.

Ran the pre-fix behavior (1 test, fails as expected) alongside the new tests against the fix (5 tests, all pass):

<img width="600" alt="test dashboard: before-fix test failing, after-fix tests passing" src="https://github.com/user-attachments/assets/4158ed9a-7ed1-4d5c-a056-54d55a6e2fd2" />

